### PR TITLE
Configure `semantic-release` to use Conventional Commits standard, and document in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      # FIXME: Remove this before release
+      - document-semantic-release
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - document-semantic-release
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      # FIXME: Remove this before release
-      - document-semantic-release
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - document-semantic-release
 
 jobs:
   release:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,11 +1,20 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     "@semantic-release/git",
     "@semantic-release/github"
   ],
-  "preset": "conventionalcommits",
   "branches": [
       "main"
   ]

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,7 +16,6 @@
     "@semantic-release/github"
   ],
   "branches": [
-      "main",
-      "document-semantic-release"
+      "main"
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,6 +16,7 @@
     "@semantic-release/github"
   ],
   "branches": [
-      "main"
+      "main",
+      "document-semantic-release"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 # asdf-yor
 
+[Yor](https://yor.io) plugin for the [asdf version manager](https://asdf-vm.com).
 
 [![Build](https://github.com/jmcvetta/asdf-yor/actions/workflows/build.yml/badge.svg)](https://github.com/jmcvetta/asdf-yor/actions/workflows/build.yml) [![Lint](https://github.com/jmcvetta/asdf-yor/actions/workflows/lint.yml/badge.svg)](https://github.com/jmcvetta/asdf-yor/actions/workflows/lint.yml)
 
 [![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
 
-
-[Yor](https://yor.io) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 [![Build](https://github.com/jmcvetta/asdf-yor/actions/workflows/build.yml/badge.svg)](https://github.com/jmcvetta/asdf-yor/actions/workflows/build.yml) [![Lint](https://github.com/jmcvetta/asdf-yor/actions/workflows/lint.yml/badge.svg)](https://github.com/jmcvetta/asdf-yor/actions/workflows/lint.yml)
 
+[![semantic-release: conventionalcommits](https://img.shields.io/badge/semantic--release-conventionalcommits-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+
 
 [Yor](https://yor.io) plugin for the [asdf version manager](https://asdf-vm.com).
 
@@ -55,6 +57,8 @@ install & manage versions.
 Contributions of any kind welcome! See the [contributing guide](contributing.md).
 
 [Thanks goes to these contributors](https://github.com/jmcvetta/asdf-yor/graphs/contributors)!
+
+Releases are generated automatically based on commit messages, using [`semantic-release`](https://github.com/semantic-release/semantic-release). Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) standard.
 
 
 # License

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ Testing Locally:
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
 #
-asdf plugin test yor https://github.com/jmcvetta/asdf-yor.git "yor --version"
+asdf plugin test yor https://github.com/ordinaryexperts/asdf-yor.git "yor --version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.

--- a/contributing.md
+++ b/contributing.md
@@ -10,3 +10,5 @@ asdf plugin test yor https://github.com/jmcvetta/asdf-yor.git "yor --version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.
+
+Releases are generated automatically based on commit messages, using [`semantic-release`](https://github.com/semantic-release/semantic-release). Commit messages must follow the [Conventional Commits](https://www.conventionalcommits.org/) standard.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "semantic-release": "^19.0.2"
   },
   "scripts": {
-    "test": "asdf plugin test yor https://github.com/ordinaryexperts/asdf-yor"
+    "test": "asdf plugin test yor https://github.com/ordinaryexperts/asdf-yor.git \"yor --version\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR configures `semantic-release` to use Conventional Commits standard, and documents semantic-release in the README.